### PR TITLE
Change client name for DCR to "Warp".

### DIFF
--- a/crates/rmcp/src/transport/auth.rs
+++ b/crates/rmcp/src/transport/auth.rs
@@ -572,7 +572,7 @@ impl AuthorizationSession {
 
         // try to dynamic register client
         let config = match auth_manager
-            .register_client("MCP Client", redirect_uri)
+            .register_client("Warp", redirect_uri)
             .await
         {
             Ok(config) => config,


### PR DESCRIPTION
Ideally we use "Warp" or "Warp Preview", as appropriate, but 80/20.