### PR TITLE
Only try to refresh access tokens if we have a refresh token or an expiry time.

### DIFF
--- a/crates/rmcp/src/transport/auth.rs
+++ b/crates/rmcp/src/transport/auth.rs
@@ -585,13 +585,16 @@ impl AuthorizationManager {
         let credentials = stored.and_then(|s| s.token_response);
 
         if let Some(creds) = credentials.as_ref() {
-            let expires_in = creds.expires_in().unwrap_or(Duration::from_secs(0));
-            if expires_in <= Duration::from_secs(0) {
-                tracing::info!("Access token expired, refreshing.");
+            // check token expiry if we have a refresh token or an expiry time
+            if creds.refresh_token().is_some() || creds.expires_in().is_some() {
+                let expires_in = creds.expires_in().unwrap_or(Duration::from_secs(0));
+                if expires_in <= Duration::from_secs(0) {
+                    tracing::info!("Access token expired, refreshing.");
 
-                let new_creds = self.refresh_token().await?;
-                tracing::info!("Refreshed access token.");
-                return Ok(new_creds.access_token().secret().to_string());
+                    let new_creds = self.refresh_token().await?;
+                    tracing::info!("Refreshed access token.");
+                    return Ok(new_creds.access_token().secret().to_string());
+                }
             }
 
             Ok(creds.access_token().secret().to_string())


### PR DESCRIPTION
When connecting to GitHub MCP as an OAuth App client (as opposed to a GitHub App client), GitHub issues a persistent access token and no refresh token.

The current logic treats a lack of an expiry time as "the token is already expired", which is incorrect in this use case, as the token _never_ expires, and we are unable to refresh it (as we were never issued a refresh token).

This fixes the issue by only attempting to refresh if we have _either_ a refresh token _or_ an expiry time.